### PR TITLE
Add Avalonia headless test project with Login VM and view tests

### DIFF
--- a/EcoBank.ci.slnf
+++ b/EcoBank.ci.slnf
@@ -5,7 +5,8 @@
       "src/Core/EcoBank.Core.csproj",
       "src/Shared/EcoBank.Shared.csproj",
       "src/Infrastructure.Xpollens/EcoBank.Infrastructure.Xpollens.csproj",
-      "src/App/EcoBank.App.csproj"
+      "src/App/EcoBank.App.csproj",
+      "tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj"
     ]
   }
 }

--- a/EcoBank.slnx
+++ b/EcoBank.slnx
@@ -24,4 +24,7 @@
   <Folder Name="/src/Browser/">
     <Project Path="src/Browser/EcoBank.Browser.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj
+++ b/tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.12" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\App\EcoBank.App.csproj" />
+    <ProjectReference Include="..\..\src\Core\EcoBank.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/EcoBank.App.Tests/Infrastructure/TestAppBuilder.cs
+++ b/tests/EcoBank.App.Tests/Infrastructure/TestAppBuilder.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(EcoBank.App.Tests.Infrastructure.TestAppBuilder))]
+
+namespace EcoBank.App.Tests.Infrastructure;
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<TestApplication>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                UseHeadlessDrawing = true
+            });
+}
+
+public sealed class TestApplication : Application;

--- a/tests/EcoBank.App.Tests/ViewModels/LoginViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/LoginViewModelTests.cs
@@ -1,0 +1,108 @@
+using EcoBank.App.Services;
+using EcoBank.App.ViewModels;
+using EcoBank.App.ViewModels.Auth;
+using EcoBank.App.ViewModels.Shell;
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Auth;
+using EcoBank.Core.Domain.Users;
+using EcoBank.Core.Ports;
+using EcoBank.Core.UseCases.Auth;
+using EcoBank.Core.UseCases.Users;
+
+namespace EcoBank.App.Tests.ViewModels;
+
+public class LoginViewModelTests
+{
+    [Fact]
+    public void LoginCommand_IsDisabled_WhenRequiredFieldsAreMissing()
+    {
+        var vm = CreateViewModel();
+
+        Assert.False(vm.LoginCommand.CanExecute(null));
+
+        vm.ClientId = "client";
+        vm.ClientSecret = "secret";
+        vm.AppUserId = "";
+
+        Assert.False(vm.LoginCommand.CanExecute(null));
+
+        vm.AppUserId = "user-1";
+
+        Assert.True(vm.LoginCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task LoginCommand_NavigatesToMainShell_AfterSuccessfulAuthentication()
+    {
+        var navigation = new FakeNavigationService();
+        var vm = CreateViewModel(navigationService: navigation);
+        vm.ClientId = "client";
+        vm.ClientSecret = "secret";
+        vm.AppUserId = "user-1";
+
+        await vm.LoginCommand.ExecuteAsync(null);
+
+        Assert.Equal(typeof(MainShellViewModel), navigation.LastNavigatedType);
+    }
+
+    private static LoginViewModel CreateViewModel(
+        INavigationService? navigationService = null,
+        ISecureStorage? secureStorage = null)
+    {
+        var context = new UserContext();
+        var authUseCase = new AuthenticateUseCase(new FakeAuthService(), context);
+        var getUserUseCase = new GetUserUseCase(new FakeUserRepository());
+        var selectUserUseCase = new SelectUserUseCase(context);
+
+        return new LoginViewModel(
+            authUseCase,
+            getUserUseCase,
+            selectUserUseCase,
+            navigationService ?? new FakeNavigationService(),
+            secureStorage ?? new FakeSecureStorage());
+    }
+
+    private sealed class FakeAuthService : IAuthService
+    {
+        public Task<TokenResponse> AuthenticateAsync(Credentials credentials, CancellationToken ct = default)
+            => Task.FromResult(new TokenResponse("token", "Bearer", 3600, DateTimeOffset.UtcNow.AddHours(1)));
+    }
+
+    private sealed class FakeUserRepository : IUserRepository
+    {
+        public Task<IReadOnlyList<User>> GetUsersAsync(int page = 1, int pageSize = 20, string? search = null, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<User>>(Array.Empty<User>());
+
+        public Task<User?> GetUserAsync(string appUserId, CancellationToken ct = default)
+            => Task.FromResult<User?>(new User(appUserId, "Test", "User", null, KycStatus.Validated, DateTimeOffset.UtcNow));
+    }
+
+    private sealed class FakeSecureStorage : ISecureStorage
+    {
+        public Task SaveAsync(string key, string value, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> LoadAsync(string key, CancellationToken ct = default) => Task.FromResult<string?>(null);
+        public Task DeleteAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeNavigationService : INavigationService
+    {
+        public ViewModelBase CurrentPage { get; private set; } = null!;
+        public event EventHandler<ViewModelBase>? PageChanged;
+        public bool CanGoBack => false;
+        public Type? LastNavigatedType { get; private set; }
+
+        public void NavigateTo(ViewModelBase page)
+        {
+            CurrentPage = page;
+            LastNavigatedType = page.GetType();
+            PageChanged?.Invoke(this, page);
+        }
+
+        public void NavigateTo<T>() where T : ViewModelBase
+        {
+            LastNavigatedType = typeof(T);
+        }
+
+        public void GoBack() { }
+    }
+}

--- a/tests/EcoBank.App.Tests/ViewModels/LoginViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/LoginViewModelTests.cs
@@ -8,6 +8,7 @@ using EcoBank.Core.Domain.Users;
 using EcoBank.Core.Ports;
 using EcoBank.Core.UseCases.Auth;
 using EcoBank.Core.UseCases.Users;
+using Xunit;
 
 namespace EcoBank.App.Tests.ViewModels;
 

--- a/tests/EcoBank.App.Tests/Views/LoginViewTests.cs
+++ b/tests/EcoBank.App.Tests/Views/LoginViewTests.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using EcoBank.App.Views.Auth;
+
+namespace EcoBank.App.Tests.Views;
+
+public class LoginViewTests
+{
+    [AvaloniaFact]
+    public void LoginView_RendersExpectedInputFields()
+    {
+        var view = new LoginView();
+
+        var textBoxes = view.GetVisualDescendants().OfType<TextBox>().ToList();
+
+        Assert.True(textBoxes.Count >= 3);
+        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre Client ID Xpollens");
+        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre Client Secret");
+        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre App User ID");
+    }
+}

--- a/tests/EcoBank.App.Tests/Views/LoginViewTests.cs
+++ b/tests/EcoBank.App.Tests/Views/LoginViewTests.cs
@@ -1,7 +1,9 @@
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.VisualTree;
 using EcoBank.App.Views.Auth;
+using Xunit;
 
 namespace EcoBank.App.Tests.Views;
 
@@ -15,8 +17,8 @@ public class LoginViewTests
         var textBoxes = view.GetVisualDescendants().OfType<TextBox>().ToList();
 
         Assert.True(textBoxes.Count >= 3);
-        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre Client ID Xpollens");
-        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre Client Secret");
-        Assert.Contains(textBoxes, box => box.Watermark?.ToString() == "Votre App User ID");
+        Assert.Contains(textBoxes, box => AutomationProperties.GetName(box) == "Client ID");
+        Assert.Contains(textBoxes, box => AutomationProperties.GetName(box) == "Client Secret");
+        Assert.Contains(textBoxes, box => AutomationProperties.GetName(box) == "App User ID");
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a dedicated test project for the Avalonia app to follow Avalonia testing best practices (headless UI host + isolated view-model tests). 
- Make it easy to run UI smoke tests and view-model unit tests that don't require a full desktop environment.

### Description

- Add a new test project `tests/EcoBank.App.Tests` with `Avalonia.Headless`, `Avalonia.Headless.XUnit`, `xunit` and related test packages in `tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj`.
- Add a headless Avalonia test application bootstrap `tests/EcoBank.App.Tests/Infrastructure/TestAppBuilder.cs` using `[assembly: AvaloniaTestApplication(...)]` so UI tests run under Avalonia’s headless test host.
- Add view-model unit tests in `tests/EcoBank.App.Tests/ViewModels/LoginViewModelTests.cs` that use fakes for ports/services to validate `LoginViewModel` command enablement and navigation behavior.
- Add a headless UI smoke test in `tests/EcoBank.App.Tests/Views/LoginViewTests.cs` that asserts the `LoginView` renders expected input fields by watermark.
- Register the new test project in the main solution file `EcoBank.slnx` and include it in the CI solution filter `EcoBank.ci.slnf` so tests are discoverable by CI.

### Testing

- Attempted to run `dotnet test EcoBank.ci.slnf`, but the command failed in this environment because the `dotnet` CLI is not installed (test execution could not be performed here).
- No other automated test runs were performed in this environment; the tests are added and ready to be executed in a developer/CI environment with .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36372af80832cb7044f031c0a6d4d)