### PR TITLE
[codex] Fix client banking UI flows

### DIFF
--- a/src/App/DependencyInjection.cs
+++ b/src/App/DependencyInjection.cs
@@ -48,6 +48,7 @@ public static class DependencyInjection
         services.AddTransient<GetCardOperationsUseCase>();
         services.AddTransient<ToggleCardLockUseCase>();
         services.AddTransient<CreatePhysicalCardUseCase>();
+        services.AddTransient<CreateVirtualCardUseCase>();
         services.AddTransient<GetBeneficiariesUseCase>();
         services.AddTransient<GetMandatesUseCase>();
         services.AddTransient<CreateSepaTransferUseCase>();

--- a/src/App/ViewModels/Accounts/AccountsViewModel.cs
+++ b/src/App/ViewModels/Accounts/AccountsViewModel.cs
@@ -148,20 +148,25 @@ public partial class AccountsViewModel : ViewModelBase
             Operations.Clear();
             if (!string.IsNullOrWhiteSpace(accountId))
             {
-                foreach (var operation in await _getOperations.ExecuteAsync(accountId: accountId, pageSize: 20, ct: ct))
+                var results = await _getOperations.ExecuteAsync(accountId: accountId, pageSize: 20, ct: ct);
+                if (results is not null)
                 {
-                    Operations.Add(operation);
+                    foreach (var operation in results)
+                    {
+                        Operations.Add(operation);
+                    }
                 }
             }
-            OnPropertyChanged(nameof(HasOperations));
-            OnPropertyChanged(nameof(HasNoOperations));
         }
         catch (Exception)
         {
             Operations.Clear();
+            ErrorMessage = "Impossible de charger les opérations.";
+        }
+        finally
+        {
             OnPropertyChanged(nameof(HasOperations));
             OnPropertyChanged(nameof(HasNoOperations));
-            ErrorMessage = "Impossible de charger les opérations.";
         }
     }
 }

--- a/src/App/ViewModels/Accounts/AccountsViewModel.cs
+++ b/src/App/ViewModels/Accounts/AccountsViewModel.cs
@@ -3,7 +3,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EcoBank.App.Services;
 using EcoBank.Core.Domain.Accounts;
+using EcoBank.Core.Domain.Operations;
 using EcoBank.Core.UseCases.Accounts;
+using EcoBank.Core.UseCases.Operations;
 
 namespace EcoBank.App.ViewModels.Accounts;
 
@@ -13,6 +15,7 @@ public partial class AccountsViewModel : ViewModelBase
     private readonly GetVirtualIbansUseCase _getVirtualIbans;
     private readonly ListBankStatementsUseCase _listBankStatements;
     private readonly GetBankStatementUseCase _getBankStatement;
+    private readonly GetOperationsUseCase _getOperations;
     private readonly ShellNavigationContext _shellNav;
 
     [ObservableProperty] private Account? _selectedAccount;
@@ -22,9 +25,12 @@ public partial class AccountsViewModel : ViewModelBase
     public ObservableCollection<Account> Accounts { get; } = [];
     public ObservableCollection<VirtualIban> VirtualIbans { get; } = [];
     public ObservableCollection<BankStatement> BankStatements { get; } = [];
+    public ObservableCollection<Operation> Operations { get; } = [];
 
     public bool HasVirtualIbans => VirtualIbans.Any();
     public bool HasBankStatements => BankStatements.Any();
+    public bool HasOperations => Operations.Any();
+    public bool HasNoOperations => !HasOperations;
     public string SelectedAccountLimitLabel => SelectedAccount is null
         ? "Sélectionnez un compte"
         : "Limites et soldes complémentaires disponibles selon le contrat Xpollens.";
@@ -34,12 +40,14 @@ public partial class AccountsViewModel : ViewModelBase
         GetVirtualIbansUseCase getVirtualIbans,
         ListBankStatementsUseCase listBankStatements,
         GetBankStatementUseCase getBankStatement,
+        GetOperationsUseCase getOperations,
         ShellNavigationContext shellNav)
     {
         _getAccounts = getAccounts;
         _getVirtualIbans = getVirtualIbans;
         _listBankStatements = listBankStatements;
         _getBankStatement = getBankStatement;
+        _getOperations = getOperations;
         _shellNav = shellNav;
     }
 
@@ -57,6 +65,7 @@ public partial class AccountsViewModel : ViewModelBase
 
             // Load bank statements for the selected account
             await LoadBankStatementsAsync(SelectedAccount?.AccountId, ct);
+            await LoadOperationsAsync(SelectedAccount?.AccountId, ct);
         }
         catch (Exception) { ErrorMessage = "Impossible de charger les comptes."; }
         finally { IsBusy = false; }
@@ -92,6 +101,7 @@ public partial class AccountsViewModel : ViewModelBase
         OnPropertyChanged(nameof(SelectedAccountLimitLabel));
         _ = LoadVirtualIbansAsync(value?.AccountId);
         _ = LoadBankStatementsAsync(value?.AccountId);
+        _ = LoadOperationsAsync(value?.AccountId);
     }
 
     private async Task LoadVirtualIbansAsync(string? accountId)
@@ -128,6 +138,30 @@ public partial class AccountsViewModel : ViewModelBase
             BankStatements.Clear();
             OnPropertyChanged(nameof(HasBankStatements));
             ErrorMessage = "Impossible de charger les relevés.";
+        }
+    }
+
+    private async Task LoadOperationsAsync(string? accountId = null, CancellationToken ct = default)
+    {
+        try
+        {
+            Operations.Clear();
+            if (!string.IsNullOrWhiteSpace(accountId))
+            {
+                foreach (var operation in await _getOperations.ExecuteAsync(accountId: accountId, pageSize: 20, ct: ct))
+                {
+                    Operations.Add(operation);
+                }
+            }
+            OnPropertyChanged(nameof(HasOperations));
+            OnPropertyChanged(nameof(HasNoOperations));
+        }
+        catch (Exception)
+        {
+            Operations.Clear();
+            OnPropertyChanged(nameof(HasOperations));
+            OnPropertyChanged(nameof(HasNoOperations));
+            ErrorMessage = "Impossible de charger les opérations.";
         }
     }
 }

--- a/src/App/ViewModels/Cards/CardsViewModel.cs
+++ b/src/App/ViewModels/Cards/CardsViewModel.cs
@@ -17,6 +17,7 @@ public partial class CardsViewModel : ViewModelBase
     private readonly ToggleCardLockUseCase _toggleCardLock;
     private readonly RequestStrongAuthenticationUseCase _requestStrongAuthentication;
     private readonly CreatePhysicalCardUseCase _createPhysicalCard;
+    private readonly CreateVirtualCardUseCase _createVirtualCard;
     private readonly ShellNavigationContext _shellNav;
 
     [ObservableProperty] private Card? _selectedCard;
@@ -39,6 +40,7 @@ public partial class CardsViewModel : ViewModelBase
         ToggleCardLockUseCase toggleCardLock,
         RequestStrongAuthenticationUseCase requestStrongAuthentication,
         CreatePhysicalCardUseCase createPhysicalCard,
+        CreateVirtualCardUseCase createVirtualCard,
         ShellNavigationContext shellNav)
     {
         _userContext = userContext;
@@ -46,6 +48,7 @@ public partial class CardsViewModel : ViewModelBase
         _toggleCardLock = toggleCardLock;
         _requestStrongAuthentication = requestStrongAuthentication;
         _createPhysicalCard = createPhysicalCard;
+        _createVirtualCard = createVirtualCard;
         _shellNav = shellNav;
     }
 
@@ -97,6 +100,31 @@ public partial class CardsViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    private async Task CreateVirtualCardAsync(CancellationToken ct)
+    {
+        IsBusy = true;
+        ClearError();
+        CardCreationMessage = "";
+        try
+        {
+            var card = await _createVirtualCard.ExecuteAsync(ct);
+            Cards.Add(card);
+            SelectedCard = card;
+            OnPropertyChanged(nameof(HasCards));
+            OnPropertyChanged(nameof(HasNoCards));
+            CardCreationMessage = "Carte virtuelle créée avec succès.";
+        }
+        catch (Exception)
+        {
+            ErrorMessage = "Impossible de créer la carte virtuelle.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
     private async Task ManageCardAsync(CancellationToken ct)
     {
         if (SelectedCard is null)
@@ -124,6 +152,14 @@ public partial class CardsViewModel : ViewModelBase
 
     [RelayCommand]
     private void ManageAlerts() => SecurityMessage = "Les plafonds et alertes carte sont affichés dans le détail de la carte.";
+
+    [RelayCommand]
+    private async Task EnrollApplePayAsync(CancellationToken ct) =>
+        await RequestWalletEnrollmentAsync("ApplePay", "Enrôlement Apple Pay lancé.", ct);
+
+    [RelayCommand]
+    private async Task EnrollXPayAsync(CancellationToken ct) =>
+        await RequestWalletEnrollmentAsync("XPay", "Enrôlement XPay lancé.", ct);
 
     [RelayCommand]
     private void ViewCardDetails() => IsDetailVisible = true;
@@ -158,6 +194,39 @@ public partial class CardsViewModel : ViewModelBase
         catch (Exception)
         {
             ErrorMessage = "Impossible de demander l'affichage du PIN.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task RequestWalletEnrollmentAsync(string walletProvider, string successMessage, CancellationToken ct)
+    {
+        if (SelectedCard is null || _userContext.SelectedUser is null)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        ClearError();
+        try
+        {
+            var result = await _requestStrongAuthentication.ExecuteAsync(
+                new StrongAuthenticationRequest(
+                    _userContext.SelectedUser.AppUserId,
+                    $"WalletEnrollment:{walletProvider}",
+                    SelectedCard.CardId,
+                    null,
+                    SelectedCard.Currency),
+                ct);
+            SecurityMessage = result.Status == StrongAuthenticationStatus.Approved
+                ? successMessage
+                : $"Demande d'authentification forte envoyée pour {walletProvider}.";
+        }
+        catch (Exception)
+        {
+            ErrorMessage = $"Impossible de lancer l'enrôlement {walletProvider}.";
         }
         finally
         {

--- a/src/App/ViewModels/Home/HomeViewModel.cs
+++ b/src/App/ViewModels/Home/HomeViewModel.cs
@@ -45,12 +45,12 @@ public partial class HomeViewModel : ViewModelBase
 
     public string WelcomeMessage =>
         _userContext.SelectedUser is { } u
-            ? $"Bonjour {u.FirstName ?? u.AppUserId}"
+            ? string.IsNullOrWhiteSpace(u.FirstName) ? "Bonjour" : $"Bonjour {u.FirstName}"
             : "Bonjour";
 
     public string GreetingName =>
         _userContext.SelectedUser is { } u
-            ? (string.IsNullOrWhiteSpace(u.FirstName) ? u.AppUserId : u.FirstName)
+            ? (string.IsNullOrWhiteSpace(u.FirstName) ? string.Empty : u.FirstName)
             : "";
 
     public HomeViewModel(

--- a/src/App/ViewModels/Profile/ProfileViewModel.cs
+++ b/src/App/ViewModels/Profile/ProfileViewModel.cs
@@ -25,7 +25,7 @@ public enum ProfileSection
 
 public partial class ProfileViewModel : ViewModelBase
 {
-    private const string TempPdfPrefix = "ecobank_";
+    private const string TempDocumentPrefix = "ecobank_";
     private readonly UserContext _userContext;
     private readonly INavigationService _navigation;
     private readonly GetUserDocumentsUseCase _getUserDocuments;
@@ -54,10 +54,12 @@ public partial class ProfileViewModel : ViewModelBase
     [ObservableProperty] private Bitmap? _documentImageBitmap;
     [ObservableProperty] private string? _documentMimeType;
     [ObservableProperty] private string? _viewingDocumentName;
+    [ObservableProperty] private string? _documentFilePath;
 
     public bool IsDocumentImage => DocumentMimeType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true;
     public bool IsDocumentPdf => string.Equals(DocumentMimeType, "application/pdf", StringComparison.OrdinalIgnoreCase);
-    public bool IsViewingDocument => DocumentImageBitmap is not null || IsDocumentPdf;
+    public bool IsDocumentFile => !string.IsNullOrWhiteSpace(DocumentFilePath);
+    public bool IsViewingDocument => DocumentImageBitmap is not null || IsDocumentFile;
 
     // Section visibility helpers
     public bool IsMainSection => CurrentSection == ProfileSection.Main;
@@ -177,8 +179,9 @@ public partial class ProfileViewModel : ViewModelBase
                 return;
             }
 
-            ViewingDocumentName = content.Name;
-            DocumentMimeType = content.ContentType ?? document.ContentType;
+            var displayName = ResolveDisplayDocumentName(content.Name, document.Name);
+            ViewingDocumentName = displayName;
+            DocumentMimeType = ResolveDocumentMimeType(content.ContentType ?? document.ContentType, displayName);
             OnPropertyChanged(nameof(IsDocumentImage));
             OnPropertyChanged(nameof(IsDocumentPdf));
 
@@ -191,26 +194,24 @@ public partial class ProfileViewModel : ViewModelBase
             }
             else if (IsDocumentPdf)
             {
-                var safeName = string.Concat(
-                    content.Name
-                        .Select(c => Array.IndexOf(Path.GetInvalidFileNameChars(), c) >= 0 ? '_' : c));
-                var tempPath = Path.Combine(Path.GetTempPath(), $"{TempPdfPrefix}{safeName}_{Guid.NewGuid():N}.pdf");
+                var tempPath = CreateTempDocumentPath(displayName);
                 await File.WriteAllBytesAsync(tempPath, content.Content, ct);
                 CleanupTempPdfFile();
                 _lastPdfTempPath = tempPath;
-                DocumentMessage = $"PDF ouvert dans le visualiseur système.";
-                try
-                {
-                    var psi = new System.Diagnostics.ProcessStartInfo(tempPath) { UseShellExecute = true };
-                    System.Diagnostics.Process.Start(psi);
-                }
-                catch
-                {
-                    DocumentMessage = $"PDF enregistré dans : {tempPath}";
-                }
+                DocumentFilePath = tempPath;
+                OnPropertyChanged(nameof(IsDocumentFile));
+                OnPropertyChanged(nameof(IsViewingDocument));
+                DocumentMessage = $"PDF prêt à être consulté.";
             }
             else
             {
+                var tempPath = CreateTempDocumentPath(displayName);
+                await File.WriteAllBytesAsync(tempPath, content.Content, ct);
+                CleanupTempPdfFile();
+                _lastPdfTempPath = tempPath;
+                DocumentFilePath = tempPath;
+                OnPropertyChanged(nameof(IsDocumentFile));
+                OnPropertyChanged(nameof(IsViewingDocument));
                 DocumentMessage = $"{document.Name} chargé ({content.Content.Length:N0} octets).";
             }
         }
@@ -232,6 +233,26 @@ public partial class ProfileViewModel : ViewModelBase
         _userContext.Reset();
         _navigation.NavigateTo<LoginViewModel>();
     }
+
+    [RelayCommand]
+    private void OpenSelectedDocumentExternally()
+    {
+        if (string.IsNullOrWhiteSpace(DocumentFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var psi = new ProcessStartInfo(DocumentFilePath) { UseShellExecute = true };
+            Process.Start(psi);
+            DocumentMessage = "Document ouvert dans le visualiseur système.";
+        }
+        catch
+        {
+            DocumentMessage = $"Document disponible dans : {DocumentFilePath}";
+        }
+    }
     
     private void ClearDocumentPreview()
     {
@@ -239,10 +260,12 @@ public partial class ProfileViewModel : ViewModelBase
         DocumentImageBitmap = null;
         DocumentMimeType = null;
         ViewingDocumentName = null;
+        DocumentFilePath = null;
         previousBitmap?.Dispose();
         OnPropertyChanged(nameof(IsViewingDocument));
         OnPropertyChanged(nameof(IsDocumentImage));
         OnPropertyChanged(nameof(IsDocumentPdf));
+        OnPropertyChanged(nameof(IsDocumentFile));
     }
 
     private void CleanupTempPdfFile()
@@ -267,6 +290,54 @@ public partial class ProfileViewModel : ViewModelBase
         {
             _lastPdfTempPath = null;
         }
+    }
+
+    private static string CreateTempDocumentPath(string documentName)
+    {
+        var safeName = string.Concat(
+            Path.GetFileNameWithoutExtension(documentName)
+                .Select(c => Array.IndexOf(Path.GetInvalidFileNameChars(), c) >= 0 ? '_' : c));
+        if (string.IsNullOrWhiteSpace(safeName))
+        {
+            safeName = "document";
+        }
+
+        var extension = Path.GetExtension(documentName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".bin";
+        }
+
+        return Path.Combine(Path.GetTempPath(), $"{TempDocumentPrefix}{safeName}_{Guid.NewGuid():N}{extension}");
+    }
+
+    private static string ResolveDisplayDocumentName(string contentName, string documentName)
+    {
+        if (!string.IsNullOrWhiteSpace(contentName) && !string.IsNullOrWhiteSpace(Path.GetExtension(contentName)))
+        {
+            return contentName;
+        }
+
+        return string.IsNullOrWhiteSpace(documentName) ? contentName : documentName;
+    }
+
+    private static string? ResolveDocumentMimeType(string? contentType, string documentName)
+    {
+        if (!string.IsNullOrWhiteSpace(contentType))
+        {
+            return contentType;
+        }
+
+        return Path.GetExtension(documentName).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".bmp" => "image/bmp",
+            ".webp" => "image/webp",
+            ".pdf" => "application/pdf",
+            _ => contentType
+        };
     }
 
     private static string FormatKycStatus(KycStatus? status) => status switch

--- a/src/App/ViewModels/Profile/ProfileViewModel.cs
+++ b/src/App/ViewModels/Profile/ProfileViewModel.cs
@@ -192,17 +192,6 @@ public partial class ProfileViewModel : ViewModelBase
                 OnPropertyChanged(nameof(IsViewingDocument));
                 DocumentMessage = $"{document.Name} chargé ({content.Content.Length:N0} octets).";
             }
-            else if (IsDocumentPdf)
-            {
-                var tempPath = CreateTempDocumentPath(displayName);
-                await File.WriteAllBytesAsync(tempPath, content.Content, ct);
-                CleanupTempPdfFile();
-                _lastPdfTempPath = tempPath;
-                DocumentFilePath = tempPath;
-                OnPropertyChanged(nameof(IsDocumentFile));
-                OnPropertyChanged(nameof(IsViewingDocument));
-                DocumentMessage = $"PDF prêt à être consulté.";
-            }
             else
             {
                 var tempPath = CreateTempDocumentPath(displayName);
@@ -212,7 +201,9 @@ public partial class ProfileViewModel : ViewModelBase
                 DocumentFilePath = tempPath;
                 OnPropertyChanged(nameof(IsDocumentFile));
                 OnPropertyChanged(nameof(IsViewingDocument));
-                DocumentMessage = $"{document.Name} chargé ({content.Content.Length:N0} octets).";
+                DocumentMessage = IsDocumentPdf
+                    ? "PDF prêt à être consulté."
+                    : $"{document.Name} chargé ({content.Content.Length:N0} octets).";
             }
         }
         catch (Exception)
@@ -292,17 +283,18 @@ public partial class ProfileViewModel : ViewModelBase
         }
     }
 
-    private static string CreateTempDocumentPath(string documentName)
+    private static string CreateTempDocumentPath(string? documentName)
     {
+        var name = string.IsNullOrWhiteSpace(documentName) ? "document" : documentName;
         var safeName = string.Concat(
-            Path.GetFileNameWithoutExtension(documentName)
+            Path.GetFileNameWithoutExtension(name)
                 .Select(c => Array.IndexOf(Path.GetInvalidFileNameChars(), c) >= 0 ? '_' : c));
         if (string.IsNullOrWhiteSpace(safeName))
         {
             safeName = "document";
         }
 
-        var extension = Path.GetExtension(documentName);
+        var extension = Path.GetExtension(name);
         if (string.IsNullOrWhiteSpace(extension))
         {
             extension = ".bin";
@@ -311,19 +303,19 @@ public partial class ProfileViewModel : ViewModelBase
         return Path.Combine(Path.GetTempPath(), $"{TempDocumentPrefix}{safeName}_{Guid.NewGuid():N}{extension}");
     }
 
-    private static string ResolveDisplayDocumentName(string contentName, string documentName)
+    private static string ResolveDisplayDocumentName(string? contentName, string? documentName)
     {
         if (!string.IsNullOrWhiteSpace(contentName) && !string.IsNullOrWhiteSpace(Path.GetExtension(contentName)))
         {
             return contentName;
         }
 
-        return string.IsNullOrWhiteSpace(documentName) ? contentName : documentName;
+        return string.IsNullOrWhiteSpace(documentName) ? contentName ?? "document" : documentName;
     }
 
-    private static string? ResolveDocumentMimeType(string? contentType, string documentName)
+    private static string? ResolveDocumentMimeType(string? contentType, string? documentName)
     {
-        if (!string.IsNullOrWhiteSpace(contentType))
+        if (!string.IsNullOrWhiteSpace(contentType) || string.IsNullOrWhiteSpace(documentName))
         {
             return contentType;
         }

--- a/src/App/ViewModels/Shell/MainShellViewModel.cs
+++ b/src/App/ViewModels/Shell/MainShellViewModel.cs
@@ -45,7 +45,7 @@ public partial class MainShellViewModel : ViewModelBase
         [
             new("home",     "Accueil",   homeVm),
             new("accounts", "Comptes",   accountsVm),
-            new("payments", "Paiements", paymentsVm),
+            new("payments", "Virements", paymentsVm),
             new("cards",    "Cartes",    cardsVm),
             new("profile",  "Profil",    profileVm),
         ];

--- a/src/App/Views/Accounts/AccountsView.axaml
+++ b/src/App/Views/Accounts/AccountsView.axaml
@@ -3,6 +3,7 @@
              xmlns:vm="using:EcoBank.App.ViewModels.Accounts"
              xmlns:home="using:EcoBank.App.ViewModels.Home"
              xmlns:domain="using:EcoBank.Core.Domain.Accounts"
+             xmlns:ops="using:EcoBank.Core.Domain.Operations"
              xmlns:ic="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              x:Class="EcoBank.App.Views.Accounts.AccountsView"
              x:DataType="vm:AccountsViewModel"
@@ -90,6 +91,50 @@
                          FontSize="12"
                          Foreground="#8A9AA5"
                          TextWrapping="Wrap"/>
+            </StackPanel>
+          </Border>
+
+          <Border Classes="EcoPanel">
+            <StackPanel Spacing="14">
+              <Grid ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0" Spacing="2">
+                  <TextBlock Text="Opérations" FontSize="15" FontWeight="Bold" Foreground="#101820"/>
+                  <TextBlock Text="Dernières opérations du compte sélectionné" FontSize="11" Foreground="#8A9AA5"/>
+                </StackPanel>
+                <ic:MaterialIcon Grid.Column="1" Kind="ReceiptTextOutline" Width="20" Height="20" Foreground="#168246" VerticalAlignment="Center"/>
+              </Grid>
+
+              <ItemsControl ItemsSource="{Binding Operations}" IsVisible="{Binding HasOperations}">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate x:DataType="ops:Operation">
+                    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12" Margin="0,0,0,12" MinHeight="44">
+                      <Border Classes="EcoIconTile">
+                        <ic:MaterialIcon Kind="{Binding Category, Converter={x:Static home:CategoryToIconConverter.Instance}}" Width="19" Height="19" Foreground="#168246" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                      </Border>
+                      <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Label}" FontSize="13" FontWeight="Bold" Foreground="#101820" TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Text="{Binding Date, StringFormat='{}{0:dd/MM/yyyy}'}" FontSize="11" Foreground="#8A9AA5"/>
+                      </StackPanel>
+                      <TextBlock Grid.Column="2" FontSize="13" FontWeight="Bold" VerticalAlignment="Center">
+                        <TextBlock.Foreground>
+                          <Binding Path="Amount" Converter="{x:Static home:AmountToColorConverter.Instance}"/>
+                        </TextBlock.Foreground>
+                        <TextBlock.Text>
+                          <MultiBinding Converter="{x:Static home:SignedMoneyTextConverter.Instance}">
+                            <Binding Path="Amount"/>
+                            <Binding Path="Currency"/>
+                          </MultiBinding>
+                        </TextBlock.Text>
+                      </TextBlock>
+                    </Grid>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+
+              <TextBlock Text="Aucune opération disponible pour ce compte."
+                         FontSize="12"
+                         Foreground="#8A9AA5"
+                         IsVisible="{Binding HasNoOperations}"/>
             </StackPanel>
           </Border>
 

--- a/src/App/Views/Cards/CardsView.axaml
+++ b/src/App/Views/Cards/CardsView.axaml
@@ -121,14 +121,15 @@
                   CornerRadius="18"
                   Padding="20"
                   ClipToBounds="True"
-                  BoxShadow="0 10 30 0 #2E101820"
+                  BoxShadow="0 10 30 0 #1A101820"
                   HorizontalAlignment="Center"
+                  Opacity="0.62"
                   IsVisible="{Binding HasNoCards}">
             <Border.Background>
               <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
-                <GradientStop Color="#07351F" Offset="0"/>
-                <GradientStop Color="#0F6738" Offset="0.58"/>
-                <GradientStop Color="#239A5B" Offset="1"/>
+                <GradientStop Color="#6F7A74" Offset="0"/>
+                <GradientStop Color="#9CA5A0" Offset="0.58"/>
+                <GradientStop Color="#C8D0CC" Offset="1"/>
               </LinearGradientBrush>
             </Border.Background>
             <Grid RowDefinitions="Auto,*,Auto">
@@ -159,19 +160,41 @@
                 </Border>
                 <StackPanel Grid.Column="1" Spacing="3" VerticalAlignment="Center">
                   <TextBlock Text="Aucune carte active" FontSize="14" FontWeight="Bold" Foreground="#101820"/>
-                  <TextBlock Text="Vous n'avez pas encore de carte. Créez votre carte EcoBank physique." FontSize="11" Foreground="#8A9AA5" TextWrapping="Wrap"/>
+                  <TextBlock Text="Vous n'avez pas encore de carte. Créez une carte EcoBank physique ou virtuelle." FontSize="11" Foreground="#8A9AA5" TextWrapping="Wrap"/>
                 </StackPanel>
               </Grid>
-              <Button Classes="Primary"
-                      Command="{Binding CreateCardCommand}"
-                      HorizontalAlignment="Stretch">
-                <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                  <ic:MaterialIcon Kind="CreditCardPlusOutline" Width="18" Height="18" Foreground="White"/>
-                  <TextBlock Text="Créer une carte physique" FontWeight="Bold"/>
-                </StackPanel>
-              </Button>
+              <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                <Button Grid.Column="0"
+                        Classes="Primary"
+                        Command="{Binding CreateCardCommand}"
+                        HorizontalAlignment="Stretch">
+                  <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                    <ic:MaterialIcon Kind="CreditCardPlusOutline" Width="18" Height="18" Foreground="White"/>
+                    <TextBlock Text="Physique" FontWeight="Bold"/>
+                  </StackPanel>
+                </Button>
+                <Button Grid.Column="1"
+                        Classes="Secondary"
+                        Command="{Binding CreateVirtualCardCommand}"
+                        HorizontalAlignment="Stretch">
+                  <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                    <ic:MaterialIcon Kind="CellphoneKey" Width="18" Height="18" Foreground="#168246"/>
+                    <TextBlock Text="Virtuelle" FontWeight="Bold"/>
+                  </StackPanel>
+                </Button>
+              </Grid>
             </StackPanel>
           </Border>
+
+          <Button Classes="Secondary"
+                  Command="{Binding CreateVirtualCardCommand}"
+                  HorizontalAlignment="Stretch"
+                  IsVisible="{Binding HasCards}">
+            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+              <ic:MaterialIcon Kind="CellphoneKey" Width="18" Height="18" Foreground="#168246"/>
+              <TextBlock Text="Créer une carte virtuelle" FontWeight="Bold"/>
+            </StackPanel>
+          </Button>
 
           <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,0">
             <StackPanel Grid.Column="0" Spacing="3">
@@ -249,6 +272,26 @@
               </StackPanel>
               <ic:MaterialIcon Grid.Column="2" Kind="ChevronRight" Width="20" Height="20" Foreground="#8A9AA5" VerticalAlignment="Center"/>
             </Grid>
+          </Border>
+
+          <Border Classes="EcoPanel" IsVisible="{Binding HasCards}">
+            <StackPanel Spacing="12">
+              <TextBlock Text="Wallets" FontSize="14" FontWeight="Bold" Foreground="#101820"/>
+              <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                <Button Grid.Column="0" Classes="Secondary" Command="{Binding EnrollApplePayCommand}">
+                  <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                    <ic:MaterialIcon Kind="Apple" Width="18" Height="18" Foreground="#168246"/>
+                    <TextBlock Text="Apple Pay" FontWeight="Bold"/>
+                  </StackPanel>
+                </Button>
+                <Button Grid.Column="1" Classes="Secondary" Command="{Binding EnrollXPayCommand}">
+                  <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                    <ic:MaterialIcon Kind="ContactlessPayment" Width="18" Height="18" Foreground="#168246"/>
+                    <TextBlock Text="XPay" FontWeight="Bold"/>
+                  </StackPanel>
+                </Button>
+              </Grid>
+            </StackPanel>
           </Border>
         </StackPanel>
       </ScrollViewer>

--- a/src/App/Views/Profile/ProfileView.axaml
+++ b/src/App/Views/Profile/ProfileView.axaml
@@ -302,9 +302,43 @@
                   <ic:MaterialIcon Kind="Close" Width="16" Height="16" Foreground="#45545F"/>
                 </Button>
               </Grid>
-              <Image Source="{Binding DocumentImageBitmap}"
-                     MaxHeight="320"
-                     Stretch="Uniform"/>
+              <Border Background="#F7FCF8"
+                      BorderBrush="#EEF2F4"
+                      BorderThickness="1"
+                      CornerRadius="14"
+                      Padding="10"
+                      MinHeight="260"
+                      MaxHeight="560"
+                      ClipToBounds="True">
+                <Image Source="{Binding DocumentImageBitmap}"
+                       Stretch="Uniform"
+                       StretchDirection="DownOnly"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"/>
+              </Border>
+            </StackPanel>
+          </Border>
+
+          <Border Classes="EcoPanel" IsVisible="{Binding IsDocumentFile}">
+            <StackPanel Spacing="12">
+              <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Grid.Column="0" Text="{Binding ViewingDocumentName}" FontSize="13" FontWeight="Bold" Foreground="#101820" TextTrimming="CharacterEllipsis"/>
+                <Button Grid.Column="1" Classes="IconBtn" Width="30" Height="30" Command="{Binding CloseDocumentPreviewCommand}">
+                  <ic:MaterialIcon Kind="Close" Width="16" Height="16" Foreground="#45545F"/>
+                </Button>
+              </Grid>
+              <Border Background="#F7FCF8" BorderBrush="#EEF2F4" BorderThickness="1" CornerRadius="14" Padding="18" MinHeight="180">
+                <StackPanel Spacing="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                  <ic:MaterialIcon Kind="FileEyeOutline" Width="42" Height="42" Foreground="#168246" HorizontalAlignment="Center"/>
+                  <TextBlock Text="{Binding DocumentFilePath}" FontSize="11" Foreground="#45545F" TextWrapping="Wrap" TextAlignment="Center"/>
+                  <Button Classes="Primary" Command="{Binding OpenSelectedDocumentExternallyCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                      <ic:MaterialIcon Kind="OpenInNew" Width="18" Height="18" Foreground="White"/>
+                      <TextBlock Text="Voir le document" FontWeight="Bold"/>
+                    </StackPanel>
+                  </Button>
+                </StackPanel>
+              </Border>
             </StackPanel>
           </Border>
 

--- a/src/Core/Ports/ICardRepository.cs
+++ b/src/Core/Ports/ICardRepository.cs
@@ -8,6 +8,7 @@ public interface ICardRepository
     Task<IReadOnlyList<Card>> GetCardsByHolderAsync(string holderExternalRef, CancellationToken ct = default);
     Task<Card?> GetCardAsync(string cardId, CancellationToken ct = default);
     Task<Card> CreatePhysicalCardAsync(string holderExternalRef, CancellationToken ct = default);
+    Task<Card> CreateVirtualCardAsync(string holderExternalRef, CancellationToken ct = default);
     Task LockCardAsync(string cardId, CancellationToken ct = default);
     Task UnlockCardAsync(string cardId, CancellationToken ct = default);
 }

--- a/src/Core/UseCases/Cards/CreateVirtualCardUseCase.cs
+++ b/src/Core/UseCases/Cards/CreateVirtualCardUseCase.cs
@@ -1,0 +1,15 @@
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Cards;
+using EcoBank.Core.Ports;
+
+namespace EcoBank.Core.UseCases.Cards;
+
+public class CreateVirtualCardUseCase(ICardRepository cardRepository, UserContext userContext)
+{
+    public Task<Card> ExecuteAsync(CancellationToken ct = default)
+    {
+        var holderRef = userContext.SelectedUser?.AppUserId
+            ?? throw new InvalidOperationException("No user selected.");
+        return cardRepository.CreateVirtualCardAsync(holderRef, ct);
+    }
+}

--- a/src/Infrastructure.Xpollens/Cards/XpollensCardRepository.cs
+++ b/src/Infrastructure.Xpollens/Cards/XpollensCardRepository.cs
@@ -12,6 +12,7 @@ namespace EcoBank.Infrastructure.Xpollens.Cards;
 /// GET  api/v2.0/card/holder/{holderExternalRef} — list cards by holder
 /// GET  api/v3.0/cards/{cardId}                  — get a single card
 /// POST api/v3.0/cards/physical                  — create a physical card
+/// POST api/v3.0/cards/virtual                   — create a virtual card
 /// POST api/v3.0/cards/{cardId}/lock             — lock a card
 /// POST api/v3.0/cards/{cardId}/unlock           — unlock a card
 /// </summary>
@@ -34,6 +35,10 @@ internal sealed record HolderCardDto(
     [property: JsonPropertyName("currency")] string? Currency);
 
 internal sealed record CreatePhysicalCardRequest(
+    [property: JsonPropertyName("holderExternalRef")] string HolderExternalRef,
+    [property: JsonPropertyName("cardPrint")] string CardPrint = "EcoBank");
+
+internal sealed record CreateVirtualCardRequest(
     [property: JsonPropertyName("holderExternalRef")] string HolderExternalRef,
     [property: JsonPropertyName("cardPrint")] string CardPrint = "EcoBank");
 
@@ -87,6 +92,17 @@ public sealed class XpollensCardRepository(HttpClient httpClient, ILogger<Xpolle
         response.EnsureSuccessStatusCode();
         var created = await response.Content.ReadFromJsonAsync<CardDto>(cancellationToken: ct)
             ?? throw new InvalidOperationException("Card creation returned no data.");
+        return Map(created);
+    }
+
+    public async Task<Card> CreateVirtualCardAsync(string holderExternalRef, CancellationToken ct = default)
+    {
+        logger.LogInformation("Creating virtual card for holder {HolderExternalRef}", holderExternalRef);
+        var request = new CreateVirtualCardRequest(holderExternalRef);
+        var response = await httpClient.PostAsJsonAsync("api/v3.0/cards/virtual", request, ct);
+        response.EnsureSuccessStatusCode();
+        var created = await response.Content.ReadFromJsonAsync<CardDto>(cancellationToken: ct)
+            ?? throw new InvalidOperationException("Virtual card creation returned no data.");
         return Map(created);
     }
 

--- a/tests/EcoBank.App.Tests/UseCases/ClientBankingUseCaseTests.cs
+++ b/tests/EcoBank.App.Tests/UseCases/ClientBankingUseCaseTests.cs
@@ -1,7 +1,11 @@
 using EcoBank.Core.Domain.Documents;
+using EcoBank.Core.Domain.Cards;
 using EcoBank.Core.Domain.Payments;
 using EcoBank.Core.Domain.Security;
 using EcoBank.Core.Ports;
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Users;
+using EcoBank.Core.UseCases.Cards;
 using EcoBank.Core.UseCases.Documents;
 using EcoBank.Core.UseCases.Payments;
 using EcoBank.Core.UseCases.Security;
@@ -46,6 +50,20 @@ public sealed class ClientBankingUseCaseTests
         Assert.Equal("card-1", repository.LastRequest?.ResourceId);
     }
 
+    [Fact]
+    public async Task CreateVirtualCard_uses_selected_user_as_holder()
+    {
+        var userContext = new UserContext();
+        userContext.SelectUser(new User("holder-1", "Alice", null, null, KycStatus.Validated, null));
+        var repository = new CapturingCardRepository();
+        var useCase = new CreateVirtualCardUseCase(repository, userContext);
+
+        var card = await useCase.ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("holder-1", repository.LastVirtualHolderRef);
+        Assert.Equal(CardType.Virtual, card.Type);
+    }
+
     private sealed class CapturingPaymentRepository : IPaymentRepository
     {
         public Task<PaymentResult> CreateSepaTransferAsync(PaymentOrder order, CancellationToken ct = default) =>
@@ -79,5 +97,32 @@ public sealed class ClientBankingUseCaseTests
             LastRequest = request;
             return Task.FromResult(new StrongAuthenticationResult("sca-1", StrongAuthenticationStatus.Pending, "Validation requise"));
         }
+    }
+
+    private sealed class CapturingCardRepository : ICardRepository
+    {
+        public string? LastVirtualHolderRef { get; private set; }
+
+        public Task<IReadOnlyList<Card>> GetCardsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task<IReadOnlyList<Card>> GetCardsByHolderAsync(string holderExternalRef, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Card>>([]);
+
+        public Task<Card?> GetCardAsync(string cardId, CancellationToken ct = default) =>
+            Task.FromResult<Card?>(null);
+
+        public Task<Card> CreatePhysicalCardAsync(string holderExternalRef, CancellationToken ct = default) =>
+            Task.FromResult(new Card("physical-1", null, CardType.Physical, CardStatus.Active, null, null, null, "EUR"));
+
+        public Task<Card> CreateVirtualCardAsync(string holderExternalRef, CancellationToken ct = default)
+        {
+            LastVirtualHolderRef = holderExternalRef;
+            return Task.FromResult(new Card("virtual-1", "4970 **** **** 1234", CardType.Virtual, CardStatus.Active, "Alice", null, null, "EUR"));
+        }
+
+        public Task LockCardAsync(string cardId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task UnlockCardAsync(string cardId, CancellationToken ct = default) => Task.CompletedTask;
     }
 }

--- a/tests/EcoBank.App.Tests/ViewModels/AccountsViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/AccountsViewModelTests.cs
@@ -36,6 +36,26 @@ public sealed class AccountsViewModelTests
         Assert.True(vm.HasOperations);
     }
 
+    [Fact]
+    public async Task Load_handles_null_operations_result()
+    {
+        var userContext = new UserContext();
+        userContext.SelectUser(new User("user-1", "Alice", null, null, KycStatus.Validated, null));
+
+        var vm = new AccountsViewModel(
+            new GetAccountsUseCase(new SingleAccountRepository(), userContext),
+            new GetVirtualIbansUseCase(new EmptyVirtualIbanRepository()),
+            new ListBankStatementsUseCase(new EmptyBankStatementRepository(), userContext),
+            new GetBankStatementUseCase(new EmptyBankStatementRepository()),
+            new GetOperationsUseCase(new NullOperationRepository()),
+            new ShellNavigationContext());
+
+        await vm.LoadCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(vm.Operations);
+        Assert.True(vm.HasNoOperations);
+    }
+
     private sealed class SingleAccountRepository : IAccountRepository
     {
         public Task<IReadOnlyList<Account>> GetAccountsAsync(string appUserId, CancellationToken ct = default) =>
@@ -84,6 +104,23 @@ public sealed class AccountsViewModelTests
                 new Operation("op-1", accountId ?? "", -12.30m, "EUR", "Paiement", OperationType.Debit, OperationStatus.Completed, DateTimeOffset.UtcNow, "Carte", null)
             ]);
         }
+
+        public Task<Operation?> GetOperationAsync(string operationId, CancellationToken ct = default) =>
+            Task.FromResult<Operation?>(null);
+    }
+
+    private sealed class NullOperationRepository : IOperationRepository
+    {
+        public Task<IReadOnlyList<Operation>> GetOperationsAsync(
+            string? accountId = null,
+            OperationType? type = null,
+            DateTimeOffset? from = null,
+            DateTimeOffset? to = null,
+            string? search = null,
+            int page = 1,
+            int pageSize = 20,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Operation>>(null!);
 
         public Task<Operation?> GetOperationAsync(string operationId, CancellationToken ct = default) =>
             Task.FromResult<Operation?>(null);

--- a/tests/EcoBank.App.Tests/ViewModels/AccountsViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/AccountsViewModelTests.cs
@@ -1,0 +1,91 @@
+using EcoBank.App.Services;
+using EcoBank.App.ViewModels.Accounts;
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Accounts;
+using EcoBank.Core.Domain.Operations;
+using EcoBank.Core.Domain.Users;
+using EcoBank.Core.Ports;
+using EcoBank.Core.UseCases.Accounts;
+using EcoBank.Core.UseCases.Operations;
+using Xunit;
+
+namespace EcoBank.App.Tests.ViewModels;
+
+public sealed class AccountsViewModelTests
+{
+    [Fact]
+    public async Task Load_fetches_operations_for_selected_account()
+    {
+        var userContext = new UserContext();
+        userContext.SelectUser(new User("user-1", "Alice", null, null, KycStatus.Validated, null));
+        var operationRepository = new CapturingOperationRepository();
+        var accountRepository = new SingleAccountRepository();
+
+        var vm = new AccountsViewModel(
+            new GetAccountsUseCase(accountRepository, userContext),
+            new GetVirtualIbansUseCase(new EmptyVirtualIbanRepository()),
+            new ListBankStatementsUseCase(new EmptyBankStatementRepository(), userContext),
+            new GetBankStatementUseCase(new EmptyBankStatementRepository()),
+            new GetOperationsUseCase(operationRepository),
+            new ShellNavigationContext());
+
+        await vm.LoadCommand.ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("acc-1", operationRepository.LastAccountId);
+        Assert.Single(vm.Operations);
+        Assert.True(vm.HasOperations);
+    }
+
+    private sealed class SingleAccountRepository : IAccountRepository
+    {
+        public Task<IReadOnlyList<Account>> GetAccountsAsync(string appUserId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Account>>([
+                new Account("acc-1", "Compte courant", AccountType.Current, 120m, "EUR", "FR761234", AccountStatus.Active)
+            ]);
+
+        public Task<Account?> GetAccountAsync(string accountId, CancellationToken ct = default) =>
+            Task.FromResult<Account?>(null);
+    }
+
+    private sealed class EmptyVirtualIbanRepository : IVirtualIbanRepository
+    {
+        public Task<IReadOnlyList<VirtualIban>> GetVirtualIbansAsync(string accountId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<VirtualIban>>([]);
+
+        public Task<VirtualIban> CreateVirtualIbanAsync(string accountId, string? label, CancellationToken ct = default) =>
+            Task.FromResult(new VirtualIban("viban-1", accountId, "FR760000", label, AccountStatus.Active));
+    }
+
+    private sealed class EmptyBankStatementRepository : IBankStatementRepository
+    {
+        public Task<IReadOnlyList<BankStatement>> ListBankStatementsAsync(string? accountId = null, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<BankStatement>>([]);
+
+        public Task<BankStatement?> GetBankStatementAsync(string bankStatementId, CancellationToken ct = default) =>
+            Task.FromResult<BankStatement?>(null);
+    }
+
+    private sealed class CapturingOperationRepository : IOperationRepository
+    {
+        public string? LastAccountId { get; private set; }
+
+        public Task<IReadOnlyList<Operation>> GetOperationsAsync(
+            string? accountId = null,
+            OperationType? type = null,
+            DateTimeOffset? from = null,
+            DateTimeOffset? to = null,
+            string? search = null,
+            int page = 1,
+            int pageSize = 20,
+            CancellationToken ct = default)
+        {
+            LastAccountId = accountId;
+            return Task.FromResult<IReadOnlyList<Operation>>([
+                new Operation("op-1", accountId ?? "", -12.30m, "EUR", "Paiement", OperationType.Debit, OperationStatus.Completed, DateTimeOffset.UtcNow, "Carte", null)
+            ]);
+        }
+
+        public Task<Operation?> GetOperationAsync(string operationId, CancellationToken ct = default) =>
+            Task.FromResult<Operation?>(null);
+    }
+}

--- a/tests/EcoBank.App.Tests/ViewModels/HomeViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/HomeViewModelTests.cs
@@ -1,0 +1,57 @@
+using EcoBank.App.Services;
+using EcoBank.App.ViewModels.Home;
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Accounts;
+using EcoBank.Core.Domain.Operations;
+using EcoBank.Core.Domain.Users;
+using EcoBank.Core.Ports;
+using EcoBank.Core.UseCases.Accounts;
+using EcoBank.Core.UseCases.Operations;
+using Xunit;
+
+namespace EcoBank.App.Tests.ViewModels;
+
+public sealed class HomeViewModelTests
+{
+    [Fact]
+    public void GreetingName_does_not_fall_back_to_user_id_when_first_name_is_missing()
+    {
+        var userContext = new UserContext();
+        userContext.SelectUser(new User("app-user-42", null, "Durand", null, KycStatus.Validated, null));
+
+        var vm = new HomeViewModel(
+            userContext,
+            new GetAccountsUseCase(new EmptyAccountRepository(), userContext),
+            new GetOperationsUseCase(new EmptyOperationRepository()),
+            new ShellNavigationContext());
+
+        Assert.Equal(string.Empty, vm.GreetingName);
+        Assert.Equal("Bonjour", vm.WelcomeMessage);
+    }
+
+    private sealed class EmptyAccountRepository : IAccountRepository
+    {
+        public Task<IReadOnlyList<Account>> GetAccountsAsync(string appUserId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Account>>([]);
+
+        public Task<Account?> GetAccountAsync(string accountId, CancellationToken ct = default) =>
+            Task.FromResult<Account?>(null);
+    }
+
+    private sealed class EmptyOperationRepository : IOperationRepository
+    {
+        public Task<IReadOnlyList<Operation>> GetOperationsAsync(
+            string? accountId = null,
+            OperationType? type = null,
+            DateTimeOffset? from = null,
+            DateTimeOffset? to = null,
+            string? search = null,
+            int page = 1,
+            int pageSize = 20,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<Operation>>([]);
+
+        public Task<Operation?> GetOperationAsync(string operationId, CancellationToken ct = default) =>
+            Task.FromResult<Operation?>(null);
+    }
+}

--- a/tests/EcoBank.App.Tests/ViewModels/MainShellViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/MainShellViewModelTests.cs
@@ -21,6 +21,6 @@ public sealed class MainShellViewModelTests
 
         var labels = vm.Tabs.Select(tab => tab.Label).ToArray();
 
-        Assert.Equal(["Accueil", "Comptes", "Paiements", "Cartes", "Profil"], labels);
+        Assert.Equal(["Accueil", "Comptes", "Virements", "Cartes", "Profil"], labels);
     }
 }

--- a/tests/EcoBank.App.Tests/ViewModels/ProfileViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/ProfileViewModelTests.cs
@@ -1,0 +1,91 @@
+using EcoBank.App.Services;
+using EcoBank.App.ViewModels;
+using EcoBank.App.ViewModels.Profile;
+using EcoBank.Core.Application;
+using EcoBank.Core.Domain.Documents;
+using EcoBank.Core.Domain.Users;
+using EcoBank.Core.Ports;
+using EcoBank.Core.UseCases.Documents;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace EcoBank.App.Tests.ViewModels;
+
+public sealed class ProfileViewModelTests
+{
+    [AvaloniaFact]
+    public async Task OpenDocument_displays_image_inside_app_when_mime_type_is_missing_but_extension_is_image()
+    {
+        var repository = new SingleDocumentRepository(
+            new UserDocumentContent("id-card", "fd04309b-9d04-4071-b38d-86a1e7dedf5d", DocumentKind.Kyc, null, TinyPng));
+        var vm = CreateViewModel(repository);
+        var document = new UserDocument("id-card", "Specimen Carte identite Recto.png", DocumentKind.Kyc, null, null);
+
+        await vm.OpenDocumentCommand.ExecuteAsync(document);
+
+        Assert.True(vm.IsDocumentImage);
+        Assert.NotNull(vm.DocumentImageBitmap);
+        Assert.Null(vm.DocumentFilePath);
+        Assert.Equal("Specimen Carte identite Recto.png", vm.ViewingDocumentName);
+    }
+
+    [Fact]
+    public async Task OpenDocument_preserves_original_extension_for_downloaded_file_preview()
+    {
+        var repository = new SingleDocumentRepository(
+            new UserDocumentContent("contract", "contrat.final.txt", DocumentKind.Kyc, "text/plain", [1, 2, 3]));
+        var vm = CreateViewModel(repository);
+        var document = new UserDocument("contract", "contrat.final.txt", DocumentKind.Kyc, "text/plain", null);
+
+        await vm.OpenDocumentCommand.ExecuteAsync(document);
+
+        Assert.False(vm.IsDocumentImage);
+        Assert.NotNull(vm.DocumentFilePath);
+        Assert.EndsWith(".txt", vm.DocumentFilePath, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ProfileViewModel CreateViewModel(IDocumentRepository repository)
+    {
+        var userContext = new UserContext();
+        userContext.SelectUser(new User("user-1", "Alice", "Durand", null, KycStatus.Validated, null));
+
+        return new ProfileViewModel(
+            userContext,
+            new FakeNavigationService(),
+            new GetUserDocumentsUseCase(repository),
+            new GetUserDocumentContentUseCase(repository),
+            new ShellNavigationContext());
+    }
+
+    private static readonly byte[] TinyPng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=");
+
+    private sealed class SingleDocumentRepository(UserDocumentContent content) : IDocumentRepository
+    {
+        public Task<IReadOnlyList<UserDocument>> GetDocumentsAsync(string appUserId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<UserDocument>>([]);
+
+        public Task<UserDocumentContent?> GetDocumentContentAsync(string appUserId, string key, DocumentKind kind, CancellationToken ct = default) =>
+            Task.FromResult<UserDocumentContent?>(content);
+    }
+
+    private sealed class FakeNavigationService : INavigationService
+    {
+        public ViewModelBase CurrentPage { get; private set; } = null!;
+        public event EventHandler<ViewModelBase>? PageChanged;
+        public bool CanGoBack => false;
+        public void NavigateTo(ViewModelBase page)
+        {
+            CurrentPage = page;
+            PageChanged?.Invoke(this, page);
+        }
+
+        public void NavigateTo<T>() where T : ViewModelBase
+        {
+        }
+
+        public void GoBack()
+        {
+        }
+    }
+}

--- a/tests/EcoBank.App.Tests/ViewModels/ProfileViewModelTests.cs
+++ b/tests/EcoBank.App.Tests/ViewModels/ProfileViewModelTests.cs
@@ -44,6 +44,21 @@ public sealed class ProfileViewModelTests
         Assert.EndsWith(".txt", vm.DocumentFilePath, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task OpenDocument_handles_missing_content_and_document_names()
+    {
+        var repository = new SingleDocumentRepository(
+            new UserDocumentContent("unknown", null!, DocumentKind.Kyc, null, [1, 2, 3]));
+        var vm = CreateViewModel(repository);
+        var document = new UserDocument("unknown", null!, DocumentKind.Kyc, null, null);
+
+        await vm.OpenDocumentCommand.ExecuteAsync(document);
+
+        Assert.NotNull(vm.DocumentFilePath);
+        Assert.EndsWith(".bin", vm.DocumentFilePath, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("document", vm.ViewingDocumentName);
+    }
+
     private static ProfileViewModel CreateViewModel(IDocumentRepository repository)
     {
         var userContext = new UserContext();


### PR DESCRIPTION
## Summary

- Fix the home greeting so missing first names no longer show the app user id.
- Rename the payments tab to Virements and list account operations in the Comptes screen.
- Add virtual card creation, disabled empty-card visuals, and Apple Pay / XPay enrollment actions.
- Improve profile document viewing so images render in-app with resize behavior and downloaded files keep their original extension.

## Root Cause

Several screens had UI fallbacks or missing bindings that exposed technical ids instead of user-facing data. Document previews also relied on the content payload name and MIME type, but Xpollens can return a technical content name without an extension while the document list has the real file name.

## Validation

- `dotnet test tests/EcoBank.App.Tests/EcoBank.App.Tests.csproj -c Debug --no-restore`
- `dotnet build src/Desktop/EcoBank.Desktop.csproj -c Debug --no-restore`

Note: full solution Android build is still blocked locally by the installed JDK 24.0.2; the Android SDK requires JDK 21.0.